### PR TITLE
Update testcase parsing logic

### DIFF
--- a/src/Hattis/Network.hs
+++ b/src/Hattis/Network.hs
@@ -141,7 +141,7 @@ parseFinished doc = liftIO $ do
 
 parseRunning :: MonadIO m => IOStateArrow () XmlTree XmlTree -> m SubmissionProgress 
 parseRunning doc = liftIO $ do
-            let testcases =  hasName "div" >>> hasAttrValue "class" (isInfixOf "testcase-popup")
+            let testcases =  hasName "div" >>> hasAttrValue "class" (isInfixOf "testcase-row")
             uncurry Running . sumap (fromIntegral . length) . span (isInfixOf "is-accepted")
                         <$> runX (doc >>> deep testcases /> getAttrValue "class")
             where sumap f = sec (+) . second f . first f


### PR DESCRIPTION
Seems like this was broken by a Kattis update at some point.